### PR TITLE
Using PMJ instead of vertebral level

### DIFF
--- a/scripts/process_data.sh
+++ b/scripts/process_data.sh
@@ -30,26 +30,6 @@ SUBJECT=`cut -d "/" -f1 <<< "$SUBJECT_SESSION"`
 SESSION=`cut -d "/" -f2 <<< "$SUBJECT_SESSION"`
 
 
-label_if_does_not_exist(){
-  local file="$1"
-  local file_seg="$2"
-  # Update global variable with segmentation file name
-  FILELABEL="${file}_label-disc"
-  FILELABELMANUAL="${PATH_DATA}/derivatives/labels/${SUBJECT_SESSION}/anat/${FILELABEL}.nii.gz"
-  echo "Looking for manual label: $FILELABELMANUAL"
-  if [[ -e $FILELABELMANUAL ]]; then
-    echo "Found! Using manual labels."
-    rsync -avzh $FILELABELMANUAL ${FILELABEL}.nii.gz
-    # Generate labeled segmentation from manual disc labels
-    sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -discfile ${FILELABEL}.nii.gz -c t1 -ofolder label_vertebrae
-  else
-    echo "Not found. Proceeding with automatic labeling."
-    # Generate labeled segmentation
-    sct_label_vertebrae -i "$T1_image" -s "${T1_image%.*}_seg.nii.gz" -ofolder label_vertebrae -c t1 -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  fi
-}
-
-
 # Go to folder where data will be copied and processed
 cd $PATH_DATA_PROCESSED
 
@@ -65,41 +45,24 @@ rsync -avzh --copy-links $PATH_DATA/$SUBJECT_SESSION $SUBJECT/
 # Go to anat folder where all structural data are located
 cd ${SUBJECT_SESSION}/anat/
 
-
 # Update SUBJECT variable to the prefix for BIDS file names, considering the "ses" entity
 SUBJECT="${SUBJECT}_${SESSION}"
-
-
 
 # T1 image file name
 T1_image=$(find . -type f -name "*_T1w.nii.gz" -print | head -n 1)
 
-
 # Contrast agnostic segmentation
 sct_deepseg -i "$T1_image" -task seg_sc_contrast_agnostic -o "${T1_image%.*}_seg.nii.gz" -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
-
-# Create a cylindrical mask centered around the spinal cord segmentation
-sct_create_mask -i "$T1_image" -p centerline,"${T1_image%.*}_seg.nii.gz" -size 35mm -f cylinder -o "${T1_image%.*}_mask.nii.gz"
-
-
-# Crop the image around the mask to focus on the region of interest
-sct_crop_image -i "$T1_image" -m "${T1_image%.*}_mask.nii.gz" -o "${T1_image%.*}_crop.nii.gz"
-
-
-# Create mid-vertebral levels in the cord (only if it does not exist)
-label_if_does_not_exist "${SUBJECT}_acq-mprage_T1w" "${SUBJECT}_acq-mprage_T1w.nii_seg"
-file_label=$FILELABEL
-
+# Detect ponto-medullary junction
+sct_detect_pmj -i "$T1_image" -c t1 -s "${T1_image%.*}_seg.nii.gz" -qc ${PATH_QC} -qc-subject ${SUBJECT}
  
-# Compute average cord CSA between C2 and C3 and other morphometric measures, and normalize them to PAM50 ('-normalize-PAM50' flag)
-sct_process_segmentation -i "${T1_image%.*}_seg.nii.gz" -vert 2:3 -vertfile ${T1_image%.*}._seg_labeled.nii.gz -perslice 1 -normalize-PAM50 1 -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
-
-
+# Compute average cord CSA at 64mm distance from the PMJ (which roughtly corresponds to C2-C3 disc, according to https://www.frontiersin.org/journals/neuroimaging/articles/10.3389/fnimg.2022.1031253/full)
+# normalize them to PAM50 ('-normalize-PAM50' flag)
+sct_process_segmentation -i "${T1_image%.*}_seg.nii.gz" -pmj "${T1_image%.*}_pmj.nii.gz" -pmj-distance 64 -perslice 1 -normalize-PAM50 1 -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
 
 # Go back to parent folder
 cd ..
-
 
 
 # Display useful info for the log

--- a/scripts/process_data.sh
+++ b/scripts/process_data.sh
@@ -59,7 +59,7 @@ sct_detect_pmj -i "$T1_image" -c t1 -s "${T1_image%.nii.gz}_seg.nii.gz" -qc ${PA
  
 # Compute average cord CSA at 64mm distance from the PMJ (which roughtly corresponds to C2-C3 disc, according to https://www.frontiersin.org/journals/neuroimaging/articles/10.3389/fnimg.2022.1031253/full)
 # normalize them to PAM50 ('-normalize-PAM50' flag)
-sct_process_segmentation -i "${T1_image%.nii.gz}_seg.nii.gz" -pmj "${T1_image%.nii.gz}_pmj.nii.gz" -pmj-distance 64 -perslice 1 -normalize-PAM50 1 -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
+sct_process_segmentation -i "${T1_image%.nii.gz}_seg.nii.gz" -pmj "${T1_image%.nii.gz}_pmj.nii.gz" -pmj-distance 64 -perslice 0 -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
 
 # Go back to parent folder
 cd ..

--- a/scripts/process_data.sh
+++ b/scripts/process_data.sh
@@ -52,14 +52,14 @@ SUBJECT="${SUBJECT}_${SESSION}"
 T1_image=$(find . -type f -name "*_MPRAGE.nii.gz" -print | head -n 1)
 
 # Contrast agnostic segmentation
-sct_deepseg -i "$T1_image" -task seg_sc_contrast_agnostic -o "${T1_image%.*}_seg.nii.gz" -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_deepseg -i "$T1_image" -task seg_sc_contrast_agnostic -o "${T1_image%.nii.gz}_seg.nii.gz" -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Detect ponto-medullary junction
-sct_detect_pmj -i "$T1_image" -c t1 -s "${T1_image%.*}_seg.nii.gz" -qc ${PATH_QC} -qc-subject ${SUBJECT}
+sct_detect_pmj -i "$T1_image" -c t1 -s "${T1_image%.nii.gz}_seg.nii.gz" -qc ${PATH_QC} -qc-subject ${SUBJECT}
  
 # Compute average cord CSA at 64mm distance from the PMJ (which roughtly corresponds to C2-C3 disc, according to https://www.frontiersin.org/journals/neuroimaging/articles/10.3389/fnimg.2022.1031253/full)
 # normalize them to PAM50 ('-normalize-PAM50' flag)
-sct_process_segmentation -i "${T1_image%.*}_seg.nii.gz" -pmj "${T1_image%.*}_pmj.nii.gz" -pmj-distance 64 -perslice 1 -normalize-PAM50 1 -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
+sct_process_segmentation -i "${T1_image%.nii.gz}_seg.nii.gz" -pmj "${T1_image%.nii.gz}_pmj.nii.gz" -pmj-distance 64 -perslice 1 -normalize-PAM50 1 -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
 
 # Go back to parent folder
 cd ..

--- a/scripts/process_data.sh
+++ b/scripts/process_data.sh
@@ -49,7 +49,7 @@ cd ${SUBJECT_SESSION}/anat/
 SUBJECT="${SUBJECT}_${SESSION}"
 
 # T1 image file name
-T1_image=$(find . -type f -name "*_T1w.nii.gz" -print | head -n 1)
+T1_image=$(find . -type f -name "*_MPRAGE.nii.gz" -print | head -n 1)
 
 # Contrast agnostic segmentation
 sct_deepseg -i "$T1_image" -task seg_sc_contrast_agnostic -o "${T1_image%.*}_seg.nii.gz" -qc ${PATH_QC} -qc-subject ${SUBJECT}


### PR DESCRIPTION
Given the difficulty to perform reliable vertebral labeling https://github.com/Mathilde-16/STOP_MS_data/issues/6, we could consider detecting the pontomedullary junction and then measuring CSA based on the distance from the PMJ, as suggested in https://www.frontiersin.org/journals/neuroimaging/articles/10.3389/fnimg.2022.1031253/full

Fixes #20
